### PR TITLE
フッター部分リンク先URL変更

### DIFF
--- a/app/views/items/shared/_footer.html.haml
+++ b/app/views/items/shared/_footer.html.haml
@@ -1,8 +1,8 @@
 !!!
-%html{:lang => "ja-JP"}
+%html{lang: "ja-JP"}
   %head
-    %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
-    %link{:href => "https://use.fontawesome.com/releases/v5.0.6/css/all.css", :rel => "stylesheet"}/
+    %meta{content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
+    %link{href: "https://use.fontawesome.com/releases/v5.0.6/css/all.css", rel: "stylesheet"}/
   %body
     .default-container
       /
@@ -15,107 +15,107 @@
             %p.app-banner-pc-inner-p 今すぐ無料ダウンロード！
             .app-banner-icon.clearfix
               %figure.app-banner-icon-figure
-                %img.app-banner-icon-img{:alt => "", :src => "//www-mercari-jp.akamaized.net/assets/img/common/common/mercari_icon.png?3654197748", :width => "68"}/
+                %img.app-banner-icon-img{alt: "", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/mercari_icon.png?3654197748", width: "68"}/
               %ul.app-banner-icon-ul
                 %li.app-banner-icon-li
-                  %a.app-banner-icon-a{:href => "https://itunes.apple.com/jp/app/id667861049?l=ja&mt=8", :target => "_blank"}
-                    %img.app-banner-icon-img{:alt => "", :height => "40", :src => "//www-mercari-jp.akamaized.net/assets/img/common/common/app-store.svg?3654197748", :width => "133"}/
+                  %a.app-banner-icon-a{href: "https://itunes.apple.com/jp/app/id667861049?l=ja&mt=8", target: "_blank"}
+                    %img.app-banner-icon-img{alt: "", :height => "40", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/app-store.svg?3654197748", width: "133"}/
                 %li.app-banner-icon-li
-                  %a.app-banner-icon-a{:href => "https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja", :target => "_blank"}
-                    %img.app-banner-icon-img{:alt => "", :height => "40", :src => "//www-mercari-jp.akamaized.net/assets/img/common/common/google-play.svg?3654197748", :width => "133"}/
+                  %a.app-banner-icon-a{href: "https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja", target: "_blank"}
+                    %img.app-banner-icon-img{alt: "", :height => "40", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/google-play.svg?3654197748", width: "133"}/
           %figure.app-banner-pc-figure
-            %img.app-banner-pc-figure-img{:alt => "", :src => "//www-mercari-jp.akamaized.net/assets/img/common/jp/download_content_pc.png?3654197748"}/
+            %img.app-banner-pc-figure-img{alt: "", src: "//www-mercari-jp.akamaized.net/assets/img/common/jp/download_content_pc.png?3654197748"}/
       %footer.global-footer
         %nav.global-footer-nav
           %ul.global-footer-nav-ul
             %li.download-app
-              %a.download-app.a{:href => "http://app.adjust.io/xio2ii?campaign=iOS&adgroup=common.footer"}
-                %img.download-app.img{:alt => "", :src => "//www-mercari-jp.akamaized.net/assets/img/common/common/mercari_icon.png?3654197748", :width => "35px"}>/
+              %a.download-app.a{href: "http://app.adjust.io/xio2ii?campaign=iOS&adgroup=common.footer"}
+                %img.download-app.img{alt: "", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/mercari_icon.png?3654197748", width: "35px"}>/
                 今すぐ無料ダウンロード！
             %li.footer-cell
               %h2.footer-head メルカリについて
               %ul.footer-cell-ul
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://about.mercari.com/"} 会社概要（運営会社）
+                  %a.footer-cell-a{href: "https://about.mercari.com/"} 会社概要（運営会社）
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/privacy/"} プライバシーポリシー
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/privacy/"} プライバシーポリシー
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/tos/"} メルカリ利用規約
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/tos/"} メルカリ利用規約
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/tos_paid_point/"} メルカリ利用規約・有償ポイントに関する特約
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/tos_paid_point/"} メルカリ利用規約・有償ポイントに関する特約
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/tos_smartphone_support/"} あんしんスマホサポート制度に関する利用特約
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/tos_smartphone_support/"} あんしんスマホサポート制度に関する利用特約
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/compliance/"} コンプライアンスポリシー
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/compliance/"} コンプライアンスポリシー
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/data_security/"} 個人データの安全管理に係る基本方針
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/data_security/"} 個人データの安全管理に係る基本方針
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/tokutei/"} 特定商取引に関する表記
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/tokutei/"} 特定商取引に関する表記
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/shikin_kessai/"} 資金決済法に基づく表示
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/shikin_kessai/"} 資金決済法に基づく表示
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://about.mercari.com/csr/safety/"} 法令順守と犯罪抑止のために
+                  %a.footer-cell-a{href: "https://about.mercari.com/csr/safety/"} 法令順守と犯罪抑止のために
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/jobs/"} 採用情報
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/jobs/"} 採用情報
             %li.footer-cell
               %h2.footer-head メルカリを見る
               %ul.footer-cell-ul
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/category/"} カテゴリー一覧
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/category/"} カテゴリー一覧
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/brand/"} ブランド一覧
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/brand/"} ブランド一覧
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/area/"} 出品地域一覧
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/area/"} 出品地域一覧
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://jp-news.mercari.com/", :target => "_blank"} 公式ブログ
+                  %a.footer-cell-a{href: "https://jp-news.mercari.com/", target: "_blank"} 公式ブログ
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://twitter.com/mercari_jp", :target => "_blank"} 公式Twitter
+                  %a.footer-cell-a{href: "https://twitter.com/mercari_jp", target: "_blank"} 公式Twitter
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.facebook.com/mercarijp", :target => "_blank"} 公式Facebook
+                  %a.footer-cell-a{href: "https://www.facebook.com/mercarijp", target: "_blank"} 公式Facebook
             %li.footer-cell
               %h2.footer-head ヘルプ＆ガイド
               %ul.footer-cell-ul
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/help_center/"} メルカリガイド
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/help_center/"} メルカリガイド
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/logo-guidelines/"} メルカリロゴ利用ガイドライン
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/logo-guidelines/"} メルカリロゴ利用ガイドライン
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://about.mercari.com/press/news/"} お知らせ
+                  %a.footer-cell-a{href: "https://about.mercari.com/press/news/"} お知らせ
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/rakuraku-mercari/"} らくらくメルカリ便とは
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/rakuraku-mercari/"} らくらくメルカリ便とは
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/yuyu-mercari/"} ゆうゆうメルカリ便とは
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/yuyu-mercari/"} ゆうゆうメルカリ便とは
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/rakuraku-ogata/"} 大型らくらくメルカリ便とは
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/rakuraku-ogata/"} 大型らくらくメルカリ便とは
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/guide/car/"} 車体取引ガイド
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/guide/car/"} 車体取引ガイド
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/refund-returns/"} 返品・返金ポリシー
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/refund-returns/"} 返品・返金ポリシー
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/safe/description/", :target => "_blank"} メルカリあんしん・あんぜん宣言！
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/safe/description/", target: "_blank"} メルカリあんしん・あんぜん宣言！
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/authenticity/"} 偽ブランド品撲滅への取り組み
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/authenticity/"} 偽ブランド品撲滅への取り組み
                 %li.footer-cell-li
-                  %a.footer-cell-a{:href => "https://www.mercari.com/jp/box/"} メルカリボックス
+                  %a.footer-cell-a{href: "https://www.mercari.com/jp/box/"} メルカリボックス
             %li.footer-cell
               %h2.footer-head 国
               %ul.footer-nav-lang
                 %li.footer-cell-li
-                  %a.footer-nav-lang-a{:href => "https://www.mercari.com/"}
-                    %img.footer-nav-lang-img{:alt => "", :src => "//www-mercari-jp.akamaized.net/assets/img/common/common/flag_us.png?3654197748", :width => "22"}>/
+                  %a.footer-nav-lang-a{href: "https://www.mercari.com/"}
+                    %img.footer-nav-lang-img{alt: "", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/flag_us.png?3654197748", width: "22"}>/
                     United States
                 %li.footer-cell-li
-                  %a.footer-nav-lang-a{:href => "https://www.mercari.com/uk/"}
-                    %img{:alt => "", :src => "//www-mercari-jp.akamaized.net/assets/img/common/common/flag_uk.png?3654197748", :width => "22"}>/
+                  %a.footer-nav-lang-a{href: "https://www.mercari.com/uk/"}
+                    %img{alt: "", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/flag_uk.png?3654197748", width: "22"}>/
                     United Kingdom
                 %li.footer-cell-li
-                  %a.footer-nav-lang-a.active{:href => "https://www.mercari.com/jp/"}
-                    %img{:alt => "", :src => "//www-mercari-jp.akamaized.net/assets/img/common/common/flag_jp.png?3654197748", :width => "22"}>/
+                  %a.footer-nav-lang-a.active{href: "/"}
+                    %img{alt: "", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/flag_jp.png?3654197748", width: "22"}>/
                     日本
-        %a.footer-logo-a{:href => "https://www.mercari.com/jp/"}
-          %img.footer-logo-img{:alt => "mercari", :height => "33", :src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-white.svg?3654197748", :width => "124"}/
+        %a.footer-logo-a{href: "/"}
+          %img.footer-logo-img{alt: "mercari", :height => "33", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-white.svg?3654197748", width: "124"}/
         %p.footer-copyright
           %small.footer-copyright-small ©2018 Mercari
-      %a.footer-sell-btn{:href => "https://www.mercari.com/jp/sell/"}
+      %a.footer-sell-btn{href: "/items/new"}
         %div.footer-sell-div 出品
         %i.fas.fa-camera.fa-3x


### PR DESCRIPTION
#WHAT
・ハッシュロケットの使用を変更。
・出品ボタン（右下赤丸のアイコン）、フッターのメルカリロゴ、日本語ボタン（言語選択部分）のリンク先変更。

#WHY
・リンク先が本家メルカリのパスになっていた為。